### PR TITLE
deployment capability, updated service client 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,15 @@
 # Makefile for kbase-cdn-js
 
-all: clean build dist
+TARGET ?= /kb/deployment
+SERVICE_NAME = cdnjs
+
+all: clean init build dist
+	
+deploy:
+	@echo "> Deploying to "
+	@echo ">  $(TARGET)/services/$(SERVICE_NAME)"
+	mkdir -p  $(TARGET)/services/$(SERVICE_NAME)/files
+	cp -pr dist/bin/*  $(TARGET)/services/$(SERVICE_NAME)/files
 
 clean:
 	@echo "> Removing all build artifacts"
@@ -15,10 +24,6 @@ dist:
 	@echo "> Building the distribution"
 	node dist
 
-start:
-	@echo "> Starting the example server"
-	node server start $(dir) &
-	
 quick:
 	@echo "> Doing a quick clean, build, start"
 	clean
@@ -28,6 +33,10 @@ quick:
 init:
 	@echo "> Initialiing the repo for work"
 	npm install
+	
+start:
+	@echo "> Starting the example server"
+	node server start $(dir) &
 	
 stop: 
 	@echo "> Stopping the example server"

--- a/packages.yml
+++ b/packages.yml
@@ -131,8 +131,8 @@ packages:
         # for now using the cdn branch from my account.
         # it is tracked with master as far as the logical version, but uses
         # cdn-style module paths.
-        packageRef: eapearson/kbase-service-clients-js
-        versions: [{bower: 'cdn', cdn: '1.4.0'}]
+        packageRef: kbase-service-clients-js
+        versions: [2.9.1]
         install: 
             method: custom
             startPath: dist/kb/service
@@ -146,48 +146,12 @@ packages:
             startPath: src
             files: ['*.js']    
 amd:
-    -
-        version: '0.1.0'
-        paths: 
-            # create from package bluebird v 3.3.4 with path blueburd
-            bluebird: [bluebird, '3.3.4', bluebird]
-            jquery: [jquery, 2.2.2, jquery]
-            underscore: [underscore, 1.8.3, underscore]
-            bootstrap: [bootstrap, 3.3.6, js/bootstrap]
-            bootstrap_css: [bootstrap, 3.3.6, css/bootstrap, css]
-            d3: [d3, 3.5.16, d3]
-            datatables: [datatables, 1.10.10, js/jquery.dataTables]
-            datatables_css: [datatables, 1.10.10, css/jquery.dataTables, css]
-            datatables_bootstrap: [datatables-bootstrap3-plugin, 0.4.0, js/datatables-bootstrap3]
-            datatables_bootstrap_css: [datatables-bootstrap3-plugin, 0.4.0, css/datatables-bootstrap3, css]
-            'font-awesome': [font-awesome, 4.3.0, css/font-awesome, css]
-            handlebars: [handlebars, 4.0.5, handlebars]
-            highlight: [highlightjs, 9.2.0, highlight.pack]
-            highlight_css: [highlightjs, 9.2.0, styles/default, css]
-            'js-yaml': [js-yaml, 3.3.1, js-yaml]
-            knockout: [knockout, 3.4.0, knockout]
-            numeral: [numeral, 1.5.3, numeral]
-            nunjucks: [nunjucks, 2.4.1, nunjucks]
-            plotly: [plotly, 1.4.1, plotly]
-            uuid: [pure-uuid, 1.3.0, uuid]
-
-            # require plugins
-            css: [require-css, 0.1.8, css]
-            text: [requirejs-text, 2.0.14, text]
-            yaml: [require-yaml, 0.1.2, yaml]
-
-            # kbase
-            kb_service: [kbase-service-clients-js, 1.4.0]
-            kb_common: [kbase-common-js, 1.5.4]
-            kb_widget_service: [kbase-widget-service, 0.1.0]
-        deps: 
-            bootstrap: [css!bootstrap_css]
-            datatables: [css!datatables_css]
-            datatables_bootstrap: [css!datatables_bootstrap_css datatables]
+    # this version is just top pick up the 2.9.1
+    # the amd feature should not be considered production ready
     - 
-        version: 0.1.1
+        version: 0.2.0
         paths: 
-            bluebird: [bluebird, '3.3.4', bluebird]
+            bluebird: [bluebird, '3.4.1', bluebird]
             jquery: [jquery, 2.2.2, jquery]
             underscore: [underscore, 1.8.3, underscore]
             bootstrap: [bootstrap, 3.3.6, js/bootstrap]
@@ -217,9 +181,9 @@ amd:
             # kbase
             # note that no third component means to use the package directory itself as the path component.
             # used for packages which are collections of modules.
-            kb_service: [kbase-service-clients-js, 1.4.0]
-            kb_common: [kbase-common-js, 1.5.4]
+            kb_service: [kbase-service-clients-js, 2.9.1]
+            kb_common: [kbase-common-js, 1.9.0]
             kb_widget_service: [kbase-widget-service, 0.1.0]
         deps: 
             bootstrap: [css!bootstrap_css]
-            datatables_bootstrap: [bootstrap, datatables, css!datatables_bootstrap_css]    
+            datatables_bootstrap: [bootstrap, datatables, css!datatables_bootstrap_css]             


### PR DESCRIPTION
It should now be deployable with

make
make deploy

which defaults to a deploy target of /kb/deployment/services/cdnjs

with the files living in /kb/deployment/services/cdnjs/files

The TARGET argument/env variable overrides /kb/deployment.

The service client dep was also updated -- we are in the process of converting over to cdn references and in the mean time have an alternate 2.x.x release series which has the same capability as the 1.x.x, but dependency relations are expressed in a cdn-compatible format
